### PR TITLE
Escape group name for jQuery

### DIFF
--- a/templates/assets/js/overview.js
+++ b/templates/assets/js/overview.js
@@ -1,5 +1,5 @@
 function toggleInstances(group) {
-	$('#' + group).fadeToggle();
+	$('#' + group.replace(/(:|\.|\[|\]|,)/g,"\\$1")).fadeToggle();
 }
 
 var storeprefix = document.location.pathname.replace('index.html','') + 'Overview';


### PR DESCRIPTION
Escape the name of the group before using it as JQuery selector, it may contain dots when it's a domain name.
Inspired by: https://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/
