### PR TITLE
Fix big instance container

### DIFF
--- a/templates/style.css
+++ b/templates/style.css
@@ -63,6 +63,8 @@ img.logo {
 #grouplist {
     float: left;
     position: absolute;
+    z-index: 1;
+    background-color: rgba(255, 255, 255, .7);
 }
 #grouplist ul {
     list-style: none;


### PR DESCRIPTION
When you have a large list of hosts and graph categories, the list was showing behind the items in the content area (smartgrid).
I added CSS to show it above the content area with a semi-transperant background.
